### PR TITLE
feat: Add support for new 'x-kick-auth' header.

### DIFF
--- a/src/client/api.client.ts
+++ b/src/client/api.client.ts
@@ -15,6 +15,7 @@ interface CallKickAPICycles {
   endpoint: string
   method?: 'head' | 'get' | 'post' | 'put' | 'delete' | 'trace' | 'options' | 'connect' | 'patch'
   options?: CycleTLSRequestOptions
+  kickAuth?: string
 }
 
 export class ApiClient {
@@ -23,6 +24,7 @@ export class ApiClient {
   private _cycleClient: CycleTLSClient
   private readonly cookieJar = new toughCookie.CookieJar()
   private bearerToken = ''
+  private kickAuth = ''
 
   private constructor(client: Kient) {
     this._client = client
@@ -54,6 +56,7 @@ export class ApiClient {
         'Accept': 'application/json',
         'Cookie': await this.cookieJar.getCookieString(requestUrl),
         'Authorization': `Bearer ${this.bearerToken}`,
+        ...(this.kickAuth && { 'x-kick-auth': this.kickAuth }),
       },
     }
 
@@ -66,6 +69,10 @@ export class ApiClient {
 
   public async setBearerToken(token: string) {
     this.bearerToken = token
+  }
+
+  public async setKickAuth(kickAuth: string) {
+    this.kickAuth = kickAuth
   }
 
   private async handleCookies(response: CycleTLSResponse, url: string) {

--- a/src/client/api.client.ts
+++ b/src/client/api.client.ts
@@ -15,7 +15,7 @@ interface CallKickAPICycles {
   endpoint: string
   method?: 'head' | 'get' | 'post' | 'put' | 'delete' | 'trace' | 'options' | 'connect' | 'patch'
   options?: CycleTLSRequestOptions
-  kickAuth?: string
+  kickAuthHeader?: string
 }
 
 export class ApiClient {
@@ -24,7 +24,7 @@ export class ApiClient {
   private _cycleClient: CycleTLSClient
   private readonly cookieJar = new toughCookie.CookieJar()
   private bearerToken = ''
-  private kickAuth = ''
+  private kickAuthHeader = ''
 
   private constructor(client: Kient) {
     this._client = client
@@ -56,7 +56,7 @@ export class ApiClient {
         'Accept': 'application/json',
         'Cookie': await this.cookieJar.getCookieString(requestUrl),
         'Authorization': `Bearer ${this.bearerToken}`,
-        ...(this.kickAuth && { 'x-kick-auth': this.kickAuth }),
+        ...(this.kickAuthHeader && { 'x-kick-auth': this.kickAuthHeader }),
       },
     }
 
@@ -71,8 +71,8 @@ export class ApiClient {
     this.bearerToken = token
   }
 
-  public async setKickAuth(kickAuth: string) {
-    this.kickAuth = kickAuth
+  public async setKickAuthHeader(kickAuthHeader: string) {
+    this.kickAuthHeader = kickAuthHeader
   }
 
   private async handleCookies(response: CycleTLSResponse, url: string) {

--- a/src/endpoints/authentication/authentication.endpoint.ts
+++ b/src/endpoints/authentication/authentication.endpoint.ts
@@ -26,7 +26,8 @@ export class AuthenticationEndpoint extends BaseEndpoint {
     return cast<TokensResponse>(response.body)
   }
 
-  public async login(credentials: LoginCredentials) {
+  public async login(credentials: LoginCredentials, kickAuth?: string) {
+    this._apiClient.setKickAuth(kickAuth || '')
     const tokens = await this.getTokens()
     const body = {
       email: credentials.email,

--- a/src/endpoints/authentication/authentication.endpoint.ts
+++ b/src/endpoints/authentication/authentication.endpoint.ts
@@ -26,8 +26,8 @@ export class AuthenticationEndpoint extends BaseEndpoint {
     return cast<TokensResponse>(response.body)
   }
 
-  public async login(credentials: LoginCredentials, kickAuth?: string) {
-    this._apiClient.setKickAuth(kickAuth || '')
+  public async login(credentials: LoginCredentials, kickAuthHeader: string = '') {
+    this._apiClient.setKickAuthHeader(kickAuthHeader)
     const tokens = await this.getTokens()
     const body = {
       email: credentials.email,


### PR DESCRIPTION
This PR aims to add an optional `x-kick-auth` header to each `callKickApi()` call.

In my case, this resolves the issue of being unable to use the `kick-token-provider` endpoint when using `client.api.authentication.login()`. This was due to a CloudFlare challenge before the response of the endpoint.

```
SOMETHING_WENT_WRONG: Failed to retrieve pre-login tokens
```

This header was verified using `curl` with and without the header on the machine receiving the CloudFlare challenge.

---

I wasn't sure if I should have added the auth token as an optional field inside of the `LoginCredentials` interface or as an extra `kickAuth` parameter when calling `login()`, so I chose the latter.