### PR TITLE
feat: add possibility to reply with sendMessage

### DIFF
--- a/docs/reference/chat-endpoint.md
+++ b/docs/reference/chat-endpoint.md
@@ -13,11 +13,11 @@ outline: deep
 
 Sends a message into the specified chatroom.
 
-| Parameter  | Type             | Required | Default | Description                                      |
-| ---------- | ---------------- | :------: | ------- | ------------------------------------------------ |
-| chatroomId | string \| number |   true   |         | The chatroom where you want to send your message |
-| message    | string           |   true   |         | The message to be sent                           |
-| replyTo    | 	{ originalMessageId: string, originalMessageContent: string, originalSenderId: number, originalSenderUsername: string } |   false   |         | Information about the original message to reply to  |
+| Parameter  | Type                 | Required | Default | Description                                         |
+| ---------- | -------------------- | :------: | ------- | --------------------------------------------------- |
+| chatroomId | string \| number     |   true   |         | The chatroom where you want to send your message    |
+| message    | string               |   true   |         | The message to be sent                              |
+| replyTo    | ChatMessageReference |  false   |         | Information about the original message to reply  to |
 
 
 ::: info Returns

--- a/docs/reference/chat-endpoint.md
+++ b/docs/reference/chat-endpoint.md
@@ -17,6 +17,8 @@ Sends a message into the specified chatroom.
 | ---------- | ---------------- | :------: | ------- | ------------------------------------------------ |
 | chatroomId | string \| number |   true   |         | The chatroom where you want to send your message |
 | message    | string           |   true   |         | The message to be sent                           |
+| replyTo    | 	{ originalMessageId: string, originalMessageContent: string, originalSenderId: number, originalSenderUsername: string } |   false   |         | Information about the original message to reply to  |
+
 
 ::: info Returns
 `Promise<SendMessageResponse>`

--- a/src/endpoints/chat/chat.endpoint.ts
+++ b/src/endpoints/chat/chat.endpoint.ts
@@ -7,11 +7,18 @@ import type { GenericApiResponse } from '@/endpoints/generic-api.response'
 import { KientApiError } from '@/errors'
 import { buildBody } from '@/utils/build-body'
 
+interface ChatMessageReference {
+  messageId: string
+  messageContent: string
+  senderId: number
+  senderUsername: string
+}
+
 /**
  * @category Endpoints
  */
 export class ChatEndpoint extends BaseEndpoint {
-  public async sendMessage(chatroomId: string | number, message: string, replyTo?: { originalMessageId: string; originalMessageContent: string; originalSenderId: number; originalSenderUsername: string }) {
+  public async sendMessage(chatroomId: string | number, message: string, replyTo?: ChatMessageReference) {
     this.checkAuthenticated()
 
     let body
@@ -21,12 +28,12 @@ export class ChatEndpoint extends BaseEndpoint {
         type: 'reply',
         metadata: {
           original_message: {
-            id: replyTo.originalMessageId,
-            content: replyTo.originalMessageContent,
+            id: replyTo.messageId,
+            content: replyTo.messageContent,
           },
           original_sender: {
-            id: replyTo.originalSenderId,
-            username: replyTo.originalSenderUsername,
+            id: replyTo.senderId,
+            username: replyTo.senderUsername,
           },
         },
       })

--- a/src/endpoints/chat/chat.endpoint.ts
+++ b/src/endpoints/chat/chat.endpoint.ts
@@ -11,10 +11,10 @@ import { buildBody } from '@/utils/build-body'
  * @category Endpoints
  */
 export class ChatEndpoint extends BaseEndpoint {
-  public async sendMessage(chatroomId: string | number, message: string, replyTo?: { originalMessageId: string, originalMessageContent: string, originalSenderId: number, originalSenderUsername: string }) {
+  public async sendMessage(chatroomId: string | number, message: string, replyTo?: { originalMessageId: string; originalMessageContent: string; originalSenderId: number; originalSenderUsername: string }) {
     this.checkAuthenticated()
 
-    let body;
+    let body
     if (replyTo) {
       body = buildBody<SendMessageInput>({
         content: message,
@@ -51,7 +51,6 @@ export class ChatEndpoint extends BaseEndpoint {
 
     return deserializedResponse
   }
-
 
   public async deleteMessage(chatroomId: string | number, messageId: string) {
     this.checkAuthenticated()

--- a/src/endpoints/chat/dto/send-message.input.ts
+++ b/src/endpoints/chat/dto/send-message.input.ts
@@ -1,4 +1,14 @@
 export interface SendMessageInput {
   content: string
-  type: 'message'
+  type: 'message' | 'reply'
+  metadata?: {
+    original_message?: {
+      id: string
+      content: string
+    }
+    original_sender?: {
+      id: number
+      username: string
+    }
+  }
 }


### PR DESCRIPTION
Hello,
This PR introduces an enhancement to the existing sendMessage function, allowing to optionally reply to a specific message. 

This feature is implemented by extending the SendMessageInput interface to accommodate reply metadata, and by adding conditional logic to the sendMessage function to handle the construction of the request body for a reply message.

Exemple of use :
```
client.on(Events.Chatroom.Message, (messageInstance) => {
  const message = messageInstance.data
  if (message.content === "ping") {
    client.api.chat.sendMessage(message.chatroom_id, "Pong!", {
      originalMessageId: message.id,
      originalMessageContent: message.content,
      originalSenderId: message.sender.id,
      originalSenderUsername: message.sender.username
    })
  }
})
```

This update does not affect the existing functionality of the sendMessage function for sending standard messages. It is a backward-compatible enhancement that introduces an additional capability for users wishing to reply directly to messages.