### PR TITLE
feat: add proxy support

### DIFF
--- a/docs/reference/authentication-endpoint.md
+++ b/docs/reference/authentication-endpoint.md
@@ -25,6 +25,7 @@ Attempts authentication with Kick.
 | Parameter   | Type             | Required | Default | Description                                            |
 | ----------- | ---------------- | :------: | ------- | ------------------------------------------------------ |
 | credentials | LoginCredentials |   true   |         | The credentials for the account that is authenticating |
+| options     | LoginOptions     |   false  |         | Optional settings for the login process                |
 
 ::: info Returns
 `Promise<void>`

--- a/src/core/api.client.ts
+++ b/src/core/api.client.ts
@@ -16,6 +16,7 @@ interface CallKickAPICycles {
   method?: 'head' | 'get' | 'post' | 'put' | 'delete' | 'trace' | 'options' | 'connect' | 'patch'
   options?: CycleTLSRequestOptions
   kickAuthHeader?: string
+  proxy?: string
 }
 
 export class ApiClient {
@@ -25,6 +26,7 @@ export class ApiClient {
   private readonly cookieJar = new toughCookie.CookieJar()
   private bearerToken = ''
   private kickAuthHeader = ''
+  private proxy = ''
 
   private constructor(client: Kient) {
     this._client = client
@@ -57,6 +59,7 @@ export class ApiClient {
         'Cookie': await this.cookieJar.getCookieString(requestUrl),
         'Authorization': `Bearer ${this.bearerToken}`,
         ...(this.kickAuthHeader && { 'x-kick-auth': this.kickAuthHeader }),
+        ...(this.proxy && { proxy: this.proxy }),
       },
     }
 
@@ -73,6 +76,10 @@ export class ApiClient {
 
   public async setKickAuthHeader(kickAuthHeader: string) {
     this.kickAuthHeader = kickAuthHeader
+  }
+
+  public async setProxy(proxy: string) {
+    this.proxy = proxy
   }
 
   private async handleCookies(response: CycleTLSResponse, url: string) {

--- a/src/core/api.client.ts
+++ b/src/core/api.client.ts
@@ -53,16 +53,15 @@ export class ApiClient {
     const defaultOptions: CycleTLSRequestOptions = {
       ja3: '771,4865-4867-4866-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-51-57-47-53-10,0-23-65281-10-11-35-16-5-51-43-13-45-28-21,29-23-24-25-256-257,0',
       userAgent: 'KICK/1.0.13 Dalvik/2.1.0(Linux; U; Android 13; Pixel 6 Pro Build / TQ1A.221205.011)',
+      ...(this.proxy && { proxy: this.proxy }),
       headers: {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
         'Cookie': await this.cookieJar.getCookieString(requestUrl),
         'Authorization': `Bearer ${this.bearerToken}`,
         ...(this.kickAuthHeader && { 'x-kick-auth': this.kickAuthHeader }),
-        ...(this.proxy && { proxy: this.proxy }),
       },
     }
-
     const response = await this._cycleClient(requestUrl, { ...defaultOptions, ...params.options }, params.method)
     await this.handleCookies(response, requestUrl)
 

--- a/src/endpoints/authentication/authentication.endpoint.ts
+++ b/src/endpoints/authentication/authentication.endpoint.ts
@@ -23,7 +23,7 @@ export class AuthenticationEndpoint extends BaseEndpoint {
     return cast<TokensResponse>(response.body)
   }
 
-  public async login(credentials: LoginCredentials, options: LoginOptions) {
+  public async login(credentials: LoginCredentials, options: LoginOptions = {}) {
     this._apiClient.setKickAuthHeader(options.kickAuthHeader || '')
     this._apiClient.setProxy(options.proxy || '')
     const tokens = await this.getTokens()

--- a/src/endpoints/authentication/authentication.endpoint.ts
+++ b/src/endpoints/authentication/authentication.endpoint.ts
@@ -6,7 +6,7 @@ import type { LoginErrorResponse, LoginResponse } from './dto/login.response'
 import type { UserResponse } from './dto/user.response'
 import type { PusherAuthenticationResponse } from './dto/pusher-authentication.response'
 import { KientIncorrectCredentials, KientInvalidCredentials, KientOTPIncorrect, KientOTPRequired } from './error'
-import type { LoginCredentials, LoginInput } from './dto/login.input'
+import type { LoginCredentials, LoginOptions, LoginInput } from './dto/login.input'
 import type { PusherAuthenticationInput } from './dto/pusher-authentication.input'
 import { KientApiError, KientUnauthenticated } from '@/errors'
 import { buildBody } from '@/utils/build-body'
@@ -23,8 +23,9 @@ export class AuthenticationEndpoint extends BaseEndpoint {
     return cast<TokensResponse>(response.body)
   }
 
-  public async login(credentials: LoginCredentials, kickAuthHeader: string = '') {
-    this._apiClient.setKickAuthHeader(kickAuthHeader)
+  public async login(credentials: LoginCredentials, options: LoginOptions) {
+    this._apiClient.setKickAuthHeader(options.kickAuthHeader || '')
+    this._apiClient.setProxy(options.proxy || '')
     const tokens = await this.getTokens()
 
     const body = buildBody<LoginInput>({

--- a/src/endpoints/authentication/dto/login.input.ts
+++ b/src/endpoints/authentication/dto/login.input.ts
@@ -10,3 +10,8 @@ export interface LoginCredentials {
   password: string
   otc?: number | string
 }
+
+export interface LoginOptions {
+  kickAuthHeader?: string
+  proxy?: string
+}


### PR DESCRIPTION
Hello,
This PR introduces the capability to specify a proxy server for callKickApi(). 
This feature is particularly useful for scenarios where you have an IP not blocked (or whitelisted) on the Kick API, but your code is executed from a different server.

By specifying the proxy, all requests will be routed through it without needing to relocate your server. Here’s how you can use this new feature:
```
await kick.api.authentication.login(
    {
        email: kick.mail,
        password: kick.password,
        otc: token,
    }, { proxy: 'http://proxyserver:port' }
)
```

For this I've created an new interface, `LoginOptions` and moved kickAuthHeader inside. This will make it easier to manage any future additions that may be necessary.

If you don't want to use an interface for this, I'm open to suggestions.