### PR TITLE
feat: add banUser & unbanUser

### DIFF
--- a/docs/reference/chat-endpoint.md
+++ b/docs/reference/chat-endpoint.md
@@ -53,3 +53,34 @@ Pins a message in the specified channel by ID.
 ::: info Returns
 `Promise<GenericApiResponse<null>>`
 :::
+
+***
+
+### <Badge type="warning">Authentication Required</Badge> <Badge type="tip">async</Badge> `banUser(channel, target, duration)`
+
+Ban a user from the specified channel.
+
+| Parameter | Type   | Required | Default | Description                                                                                                    |
+| --------- | ------ | :------: | ------- | -------------------------------------------------------------------------------------------------------------- |
+| channel   | string |   true   |         | The channel where you want to ban the user                                                                     |
+| target    | string |   true   |         | The username of the user you want to ban                                                                       |
+| duration  | number |   false  |         | Duration in minutes for how long the ban should last. If not provided, the ban is considered permanent         |
+
+::: info Returns
+`Promise<GenericApiResponse<null>>`
+:::
+
+***
+
+### <Badge type="warning">Authentication Required</Badge> <Badge type="tip">async</Badge> `unbanUser(channel, target)`
+
+Unban a user from the specified channel.
+
+| Parameter | Type   | Required | Default | Description                                        |
+| --------- | ------ | :------: | ------- | -------------------------------------------------- |
+| channel   | string |   true   |         | The channel from which you want to unban the user  |
+| target    | string |   true   |         | The username of the user you want to unban         |
+
+::: info Returns
+`Promise<GenericApiResponse<null>>`
+:::

--- a/src/endpoints/chat/chat.endpoint.ts
+++ b/src/endpoints/chat/chat.endpoint.ts
@@ -3,6 +3,7 @@ import { BaseEndpoint } from '../endpoint.base'
 import type { SendMessageResponse } from './dto/send-message.response'
 import type { PinMessageInput } from './dto/pin-message.input'
 import type { SendMessageInput } from './dto/send-message.input'
+import type { BanUserInput } from './dto/ban-user.input'
 import type { GenericApiResponse } from '@/endpoints/generic-api.response'
 import { KientApiError } from '@/errors'
 import { buildBody } from '@/utils/build-body'
@@ -103,4 +104,55 @@ export class ChatEndpoint extends BaseEndpoint {
 
     return deserializedResponse
   }
+
+  public async banUser(channel: string, target: string, duration?: number) {
+    this.checkAuthenticated()
+
+    let body
+    if (typeof duration === 'undefined') {
+      body = buildBody<BanUserInput>({
+        banned_username: target,
+        permanent: true,
+      });
+    } else {
+      body = buildBody<BanUserInput>({
+        banned_username: target,
+        duration: duration,
+        permanent: false,
+      });
+    }
+    const response = await this._apiClient.callKickApi({
+      endpoint: `api/v2/channels/${channel}/bans`,
+      method: 'post',
+      options: {
+        body: body,
+      },
+    })
+    if (response.status !== 200)
+      throw new KientApiError('Failed to ban user', { cause: response })
+
+    const deserializedResponse = cast<GenericApiResponse<null>>(response.body)
+    if (deserializedResponse.status.error)
+      throw new KientApiError(deserializedResponse.status, { cause: response })
+
+    return deserializedResponse
+  }
+
+  public async unbanUser(channel: string, target: string) {
+    this.checkAuthenticated()
+  
+    const response = await this._apiClient.callKickApi({
+      endpoint: `api/v2/channels/${channel}/bans/${target}`,
+      method: 'delete',
+    })
+    if (response.status !== 201)
+      throw new KientApiError('Failed to unban user', { cause: response })
+
+    const deserializedResponse = cast<GenericApiResponse<null>>(response.body)
+    if (deserializedResponse.status.error)
+      throw new KientApiError(deserializedResponse.status, { cause: response })
+
+    return deserializedResponse
+  }
+
 }

--- a/src/endpoints/chat/dto/ban-user.input.ts
+++ b/src/endpoints/chat/dto/ban-user.input.ts
@@ -1,0 +1,6 @@
+export interface BanUserInput {
+    banned_username: string
+    duration?: number
+    permanent: boolean
+  }
+  


### PR DESCRIPTION
Hello,

This PR adds two new methods to enhance user management within channels: banUser and unbanUser.

The banUser method enables the banning of a user from a channel for a specified duration. If no duration is provided, the ban is considered permanent. 
Exemple with 60 minutes as delay:

```await client.api.chat.banUser('streamer_name', 'targetUsername', 60)```


The unbanUser method allows for the removal of a ban from a user, granting them access to the channel once again. 
Exemple:

```await client.api.chat.unbanUser('streamer_name', 'targetUsername')```




