### PR TITLE
fix: Update pusher app key

### DIFF
--- a/src/core/ws.client.ts
+++ b/src/core/ws.client.ts
@@ -7,7 +7,7 @@ import { KientSubscriptionFailed } from '@/errors'
 
 export class WsClient {
   private readonly _client: Kient
-  private readonly PUSHER_APP_KEY = '32cbd69e4b950bf9767'
+  private readonly PUSHER_APP_KEY = '32cbd69e4b950bf97679'
   private readonly pusher: Pusher
 
   public constructor(client: Kient) {


### PR DESCRIPTION
PR #18 current pusher key missing 1 digit. Supposed to be `32cbd69e4b950bf97679`.