### PR TITLE
feat: Proxy support

### DIFF
--- a/src/core/api.client.ts
+++ b/src/core/api.client.ts
@@ -54,6 +54,7 @@ export class ApiClient {
       ja3: '771,4865-4867-4866-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-51-57-47-53-10,0-23-65281-10-11-35-16-5-51-43-13-45-28-21,29-23-24-25-256-257,0',
       userAgent: 'KICK/1.0.13 Dalvik/2.1.0(Linux; U; Android 13; Pixel 6 Pro Build / TQ1A.221205.011)',
       ...(this.proxy && {proxy: this.proxy}),
+      ...(this.proxy && { proxy: this.proxy }),
       headers: {
         'Content-Type': 'application/json',
         'Accept': 'application/json',

--- a/src/core/api.client.ts
+++ b/src/core/api.client.ts
@@ -53,7 +53,6 @@ export class ApiClient {
     const defaultOptions: CycleTLSRequestOptions = {
       ja3: '771,4865-4867-4866-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-51-57-47-53-10,0-23-65281-10-11-35-16-5-51-43-13-45-28-21,29-23-24-25-256-257,0',
       userAgent: 'KICK/1.0.13 Dalvik/2.1.0(Linux; U; Android 13; Pixel 6 Pro Build / TQ1A.221205.011)',
-      ...(this.proxy && {proxy: this.proxy}),
       ...(this.proxy && { proxy: this.proxy }),
       headers: {
         'Content-Type': 'application/json',

--- a/src/core/api.client.ts
+++ b/src/core/api.client.ts
@@ -16,6 +16,7 @@ interface CallKickAPICycles {
   method?: 'head' | 'get' | 'post' | 'put' | 'delete' | 'trace' | 'options' | 'connect' | 'patch'
   options?: CycleTLSRequestOptions
   kickAuthHeader?: string
+  proxy?: string
 }
 
 export class ApiClient {
@@ -25,6 +26,7 @@ export class ApiClient {
   private readonly cookieJar = new toughCookie.CookieJar()
   private bearerToken = ''
   private kickAuthHeader = ''
+  private proxy = ''
 
   private constructor(client: Kient) {
     this._client = client
@@ -51,6 +53,7 @@ export class ApiClient {
     const defaultOptions: CycleTLSRequestOptions = {
       ja3: '771,4865-4867-4866-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-51-57-47-53-10,0-23-65281-10-11-35-16-5-51-43-13-45-28-21,29-23-24-25-256-257,0',
       userAgent: 'KICK/1.0.13 Dalvik/2.1.0(Linux; U; Android 13; Pixel 6 Pro Build / TQ1A.221205.011)',
+      ...(this.proxy && {proxy: this.proxy}),
       headers: {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
@@ -73,6 +76,10 @@ export class ApiClient {
 
   public async setKickAuthHeader(kickAuthHeader: string) {
     this.kickAuthHeader = kickAuthHeader
+  }
+
+  public async setProxy(proxy: string) {
+    this.proxy = proxy
   }
 
   private async handleCookies(response: CycleTLSResponse, url: string) {

--- a/src/kient.ts
+++ b/src/kient.ts
@@ -49,8 +49,9 @@ export class Kient extends EventEmitter<KientEventEmitters> {
   }
 
   /** @internal */
-  private async init() {
+  private async init(options: options) {
     this._apiClient = await ApiClient.create(this)
+    this._apiClient.setProxy(options.proxy || '')
     this._endpoints = {
       authentication: new AuthenticationEndpoint(this),
       channel: new ChannelEndpoint(this),
@@ -72,9 +73,8 @@ export class Kient extends EventEmitter<KientEventEmitters> {
    * Creates a new instance of Kient
    */
   public static async create(options: LoginOptions = {}) {
-    const kient = new Kient()
+    const kient = new Kient(options)
     await kient.init()
-    this._apiClient.setProxy(options.proxy || '')
     return kient
   }
 

--- a/src/kient.ts
+++ b/src/kient.ts
@@ -44,12 +44,12 @@ export class Kient extends EventEmitter<KientEventEmitters> {
   public authenticated = false
 
   /** @internal */
-  private constructor() {
+  private constructor(private options: LoginOptions = {}) {
     super()
   }
 
   /** @internal */
-  private async init(options) {
+  private async init(options: LoginOptions) {
     this._apiClient = await ApiClient.create(this)
     this._apiClient.setProxy(options.proxy || '')
     this._endpoints = {
@@ -74,7 +74,7 @@ export class Kient extends EventEmitter<KientEventEmitters> {
    */
   public static async create(options: LoginOptions = {}) {
     const kient = new Kient(options)
-    await kient.init()
+    await kient.init(options)
     return kient
   }
 

--- a/src/kient.ts
+++ b/src/kient.ts
@@ -27,6 +27,10 @@ interface WsHandlers {
   privateLivestream: PrivateLivestreamSocket
 }
 
+interface LoginOptions {
+  proxy?: string
+}
+
 /**
  * Entry class into Kient
  */
@@ -67,9 +71,10 @@ export class Kient extends EventEmitter<KientEventEmitters> {
   /**
    * Creates a new instance of Kient
    */
-  public static async create() {
+  public static async create(options: LoginOptions = {}) {
     const kient = new Kient()
     await kient.init()
+    this._apiClient.setProxy(options.proxy || '')
     return kient
   }
 

--- a/src/kient.ts
+++ b/src/kient.ts
@@ -49,7 +49,7 @@ export class Kient extends EventEmitter<KientEventEmitters> {
   }
 
   /** @internal */
-  private async init(options: options) {
+  private async init(options) {
     this._apiClient = await ApiClient.create(this)
     this._apiClient.setProxy(options.proxy || '')
     this._endpoints = {


### PR DESCRIPTION
Added optional proxy support when creating Kient `Kient.create({ proxy: 'http://proxyserver:port' })` based the code on the other pull request's suggestions