### PR TITLE
fix: improve cycletls request options

### DIFF
--- a/src/core/api.client.ts
+++ b/src/core/api.client.ts
@@ -62,10 +62,10 @@ export class ApiClient {
       headers: {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
-        'Sec-Fetch-Mode': 'navigate',
-        'Sec-Fetch-Site': 'same-origin',
         'Cookie': cookie,
         'Authorization': `Bearer ${this.bearerToken}`,
+        'Sec-Fetch-Mode': 'navigate',
+        'Sec-Fetch-Site': 'same-origin',
         ...(this.kickAuthHeader && { 'x-kick-auth': this.kickAuthHeader }),
       },
     }

--- a/src/core/api.client.ts
+++ b/src/core/api.client.ts
@@ -52,7 +52,7 @@ export class ApiClient {
   public async callKickApi(params: CallKickAPICycles) {
     const requestUrl = `https://kick.com/${params.endpoint}`
     const cookie = await this.cookieJar.getCookieString(requestUrl)
-    if (cookie && !cookie.includes('XSRF-TOKEN'))
+    if (params.endpoint === 'mobile/login' && cookie && !cookie.includes('XSRF-TOKEN='))
       throw new KientApiError('Failed to get XSRF-TOKEN cookie')
 
     const defaultOptions: CycleTLSRequestOptions = {

--- a/src/core/api.client.ts
+++ b/src/core/api.client.ts
@@ -57,7 +57,7 @@ export class ApiClient {
 
     const defaultOptions: CycleTLSRequestOptions = {
       ja3: '771,4865-4867-4866-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-51-57-47-53-10,0-23-65281-10-11-35-16-5-51-43-13-45-28-21,29-23-24-25-256-257,0',
-      userAgent: 'KICK/39.7.35 Dalvik/2.1.0(Linux; U; Android 13; Pixel 6 Pro Build / TQ1A.221205.011)',
+      userAgent: 'KICK/39.9.4 Dalvik/2.1.0(Linux; U; Android 13; Pixel 6 Pro Build / TQ1A.221205.011)',
       ...(this.proxy && { proxy: this.proxy }),
       headers: {
         'Content-Type': 'application/json',

--- a/src/core/api.client.ts
+++ b/src/core/api.client.ts
@@ -5,6 +5,7 @@ import initCycleTLS from 'cycletls'
 import exitHook from 'exit-hook'
 import toughCookie from 'tough-cookie'
 import type { Kient } from '../kient'
+import { KientApiError } from '@/errors'
 
 // interface CallKickAPI {
 //   endpoint: string
@@ -50,14 +51,20 @@ export class ApiClient {
 
   public async callKickApi(params: CallKickAPICycles) {
     const requestUrl = `https://kick.com/${params.endpoint}`
+    const cookie = await this.cookieJar.getCookieString(requestUrl)
+    if (cookie && !cookie.includes('XSRF-TOKEN'))
+      throw new KientApiError('Failed to get XSRF-TOKEN cookie')
+
     const defaultOptions: CycleTLSRequestOptions = {
       ja3: '771,4865-4867-4866-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-51-57-47-53-10,0-23-65281-10-11-35-16-5-51-43-13-45-28-21,29-23-24-25-256-257,0',
-      userAgent: 'KICK/1.0.13 Dalvik/2.1.0(Linux; U; Android 13; Pixel 6 Pro Build / TQ1A.221205.011)',
+      userAgent: 'KICK/39.7.35 Dalvik/2.1.0(Linux; U; Android 13; Pixel 6 Pro Build / TQ1A.221205.011)',
       ...(this.proxy && { proxy: this.proxy }),
       headers: {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
-        'Cookie': await this.cookieJar.getCookieString(requestUrl),
+        'Sec-Fetch-Mode': 'navigate',
+        'Sec-Fetch-Site': 'same-origin',
+        'Cookie': cookie,
         'Authorization': `Bearer ${this.bearerToken}`,
         ...(this.kickAuthHeader && { 'x-kick-auth': this.kickAuthHeader }),
       },


### PR DESCRIPTION
I don't know about you, but I've been getting a lot of cloudflare challenges on Kient requests lately, but with these changes, I have been able to significantly reduce the cloudflare blocks. So that's why I'm doing this PR.


Plus, I added this line because, rarely, during authentication, the response from the `sanctum/csrf` request does not include the `XSRF-TOKEN` cookie.
https://github.com/zSoulweaver/kient/blob/9c0939ba7dc3237c32c2cdb5bd30c1b59eea15a4/src/core/api.client.ts#L54-L56