### PR TITLE
feat: support getting channels by slug

### DIFF
--- a/example/get-channels.ts
+++ b/example/get-channels.ts
@@ -12,3 +12,9 @@ kient.setAuthToken(env.KICK_TOKEN as string)
 
 const specificUser = await kient.api.channel.getById(676)
 console.log(specificUser.toJSON())
+
+// const multipleUsersBySlugs = await kient.api.channel.getBySlugs(['kient', 'user1', 'user2'])
+// console.log(kientToJSON(multipleUsersBySlugs))
+
+// const specificUserBySlug = await kient.api.channel.getBySlug('kient')
+// console.log(specificUserBySlug.toJSON())

--- a/src/api/channel/get-channels.ts
+++ b/src/api/channel/get-channels.ts
@@ -26,12 +26,7 @@ export interface ChannelResponse {
 
 type GetChannelResponse = APIResponse<ChannelResponse[]>
 
-export async function getChannelsByID(kient: Kient, ids: number[] = []) {
-	const params = new URLSearchParams()
-	for (const id of ids) {
-		params.append('broadcaster_user_id', id.toString())
-	}
-
+async function fetchChannels(kient: Kient, params: URLSearchParams): Promise<Channel[]> {
 	const response = await kient._apiClient.fetch<GetChannelResponse>(`/channels?${params}`)
 
 	const channelInstances = []
@@ -59,4 +54,20 @@ export async function getChannelsByID(kient: Kient, ids: number[] = []) {
 	}
 
 	return channelInstances
+}
+
+export async function getChannelsByID(kient: Kient, ids: number[] = []) {
+	const params = new URLSearchParams()
+	for (const id of ids) {
+		params.append('broadcaster_user_id', id.toString())
+	}
+	return fetchChannels(kient, params)
+}
+
+export async function getChannelsBySlugs(kient: Kient, slugs: string[] = []) {
+	const params = new URLSearchParams()
+	for (const slug of slugs) {
+		params.append('slug', slug)
+	}
+	return fetchChannels(kient, params)
 }

--- a/src/api/channel/index.ts
+++ b/src/api/channel/index.ts
@@ -1,5 +1,5 @@
 import { APIBase } from '../api-base'
-import { getChannelsByID } from './get-channels'
+import { getChannelsByID, getChannelsBySlugs } from './get-channels'
 
 /**
  * Description placeholder
@@ -23,6 +23,24 @@ export class ChannelAPI extends APIBase {
 	 */
 	async getById(id: number) {
 		return (await getChannelsByID(this.kient, [id]))[0]
+	}
+
+	/**
+	 * Returns an array of channel by an array of channel slugs
+	 *
+	 * @param slugs Accepts an array of channel slugs that will be queried for
+	 */
+	getBySlugs(slugs: string[]) {
+		return getChannelsBySlugs(this.kient, slugs)
+	}
+
+	/**
+	 * Returns a singular channel by slug
+	 *
+	 * @param slug Accepts a singular channel slug that will be queried for
+	 */
+	async getBySlug(slug: string) {
+		return (await getChannelsBySlugs(this.kient, [slug]))[0]
 	}
 
 	/**


### PR DESCRIPTION
Kick just added the ability to get channel(s) using the slug. I've added support for it in Kient.

I've moved the fetching and creation of the `channelInstances` array to a function to prevent duplicating code, if that's okay with you.